### PR TITLE
add user can log in with cookies and delete cookies on logout

### DIFF
--- a/test/acceptance/persistent_authentication_test.rb
+++ b/test/acceptance/persistent_authentication_test.rb
@@ -1,0 +1,39 @@
+require_relative '../acceptance_helper'
+
+class PersistentAuthenticationTest < AcceptanceTestCase
+  def setup
+    super
+    validator = SecureRandom.hex
+    alice = User.create!(username: 'alice', github_id: 1, email: "alice@example.com", token_digest: Digest::SHA256.hexdigest(validator))
+    @auth_token = AuthToken.create(selector: SecureRandom.hex, expiration: Time.now + 2592000, user_id: alice.id)
+    Capybara.current_session.driver.browser.set_cookie("validator=#{validator}")
+    Capybara.current_session.driver.browser.set_cookie("token=#{@auth_token.selector}")
+  end
+
+  def test_valid_cookies
+    visit '/'
+
+    assert_content 'alice'
+  end
+
+  def test_invalid_validator_cookie
+    Capybara.current_session.driver.browser.set_cookie("validator=incorrectvalidator")
+    visit '/'
+
+    refute_content 'alice'
+  end
+
+  def test_invalid_token_cookie
+    Capybara.current_session.driver.browser.set_cookie("token=invalidtoken")
+    visit '/'
+
+    refute_content 'alice'
+  end
+
+  def test_expired_auth_token
+    @auth_token.update!(expiration: Time.now - 1000)
+    visit '/'
+
+    refute_content 'alice'
+  end
+end

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -83,7 +83,7 @@ class UserTest < Minitest::Test
     user = User.create!(username: 'some_github_username',
                         github_id: 1234,
                         token_digest: Digest::SHA256.hexdigest("4567"))
-    auth_token = AuthToken.create(selector: "abcd", user_id: user.id)
+    auth_token = AuthToken.create(selector: "abcd", user_id: user.id, expiration: Time.now + 2592000)
 
     result = User.find_by_persistent_cookie(auth_token.selector, "4567")
 


### PR DESCRIPTION
@adriennedomingus The changes here:
- adds a check for whether the token is expired
- deletes cookies upon logout
- resets the expiration time at login

I rewrote the line that created the auth_token, since a one-to-one relation doesn't quite behave the same as a has_many relation, i.e.  `user.auth_token.create` actually has a no method error when a user doesn't have an auth_token.

Some stuff I'm trying to figure out:
Should the validator and token keys be wrapped inside a parent key, eg. cookies[:exercism][:token]?
There are no tests here, I manually tested the following scenarios:
- session has a valid github_id but no persistent cookies => successful login
- no session[:github_id] but has valid persistent cookies and token is not expired => successful login
- no session[:github_id] but has invalid persistent cookies and token is not expired => error
- no session[:github_id] but has valid persistent cookies and token is expired => error

I just saw in the [contributions readme](https://github.com/adriennedomingus/exercism.io/blob/persistent_authentication/CONTRIBUTING.md) on getting oauth to work in dev, should we work on that and perhaps figure out testing?
